### PR TITLE
chore: bump pass-cli baseline to v1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![CI](https://github.com/hesreallyhim/proton-pass-community-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/hesreallyhim/proton-pass-community-mcp/actions/workflows/ci.yml)
 [![Production Hygiene](https://github.com/hesreallyhim/proton-pass-community-mcp/actions/workflows/production-hygiene.yml/badge.svg)](https://github.com/hesreallyhim/proton-pass-community-mcp/actions/workflows/production-hygiene.yml)
+![NPM Version](https://img.shields.io/npm/v/proton-pass-community-mcp?style=flat&color=forestgreen)
 
 `proton-pass-community-mcp` is an MCP server for Proton Pass, with broad coverage of `pass-cli` operations.
 
@@ -13,6 +14,8 @@ It is designed as a production-ready integration layer:
 
 - typed tool inputs with `zod`
 - stdio transport for MCP clients
+
+### 📌 Current Version of `pass-cli` used in development: v1.9.0
 
 ## Available Tools
 
@@ -28,6 +31,8 @@ The server exposes the following MCP tool surface:
 | `list_vaults`                     | List vaults                                      |
 | `list_shares`                     | List shares                                      |
 | `list_invites`                    | List pending invitations                         |
+| `accept_invite`                   | Accept an invitation token                       |
+| `reject_invite`                   | Reject an invitation token                       |
 | `view_settings`                   | View current Proton Pass CLI settings            |
 | `list_vault_members`              | List members of a specific vault                 |
 | `update_vault_member`             | Update a vault member role                       |
@@ -120,8 +125,6 @@ These template resources are example well-formed payloads from `pass-cli --get-t
 - Node.js `24` (`.nvmrc`)
 - `pass-cli` installed and authenticated
 - MCP client capable of stdio transport
-
-### 📌 Current Baseline Version of `pass-cli` used in development: v1.7.0
 
 ## Run Locally
 

--- a/docs/upstream/PASS_CLI_SOURCE_METADATA.json
+++ b/docs/upstream/PASS_CLI_SOURCE_METADATA.json
@@ -1,6 +1,6 @@
 {
   "upstream_repo": "https://github.com/protonpass/pass-cli",
-  "latest_known_version": "1.8.0",
+  "latest_known_version": "1.9.0",
   "latest_known_version_source": "https://api.github.com/repos/protonpass/pass-cli/tags?per_page=100",
   "latest_known_version_changelog_source": "https://raw.githubusercontent.com/protonpass/pass-cli/main/CHANGELOG.md",
   "latest_known_version_published_date": "2026-03-23",

--- a/src/pass-cli/version.ts
+++ b/src/pass-cli/version.ts
@@ -1,7 +1,7 @@
 import type { PassCliRunner } from "./runner.js";
 import { joinStdoutStderr } from "./output.js";
 
-const PROJECT_PASS_CLI_BASELINE_VERSION = "1.6.1";
+const PROJECT_PASS_CLI_BASELINE_VERSION = "1.9.0";
 
 type Semver = { major: number; minor: number; patch: number };
 type CompatibilityStatus = "equal" | "compatible" | "possibly_incompatible";

--- a/test/fixtures/pass-cli-mock.sh
+++ b/test/fixtures/pass-cli-mock.sh
@@ -15,7 +15,7 @@ if [[ "$cmd1" == "test" ]]; then
 fi
 
 if [[ "$cmd1" == "--version" ]]; then
-  printf '1.6.1 (mock)\n'
+  printf '1.9.0 (mock)\n'
   exit 0
 fi
 

--- a/test/server/read-only-core.test.ts
+++ b/test/server/read-only-core.test.ts
@@ -33,7 +33,7 @@ describe("read-only handlers", () => {
     const result = await checkPassCliVersion(runner);
 
     expect(runner).toHaveBeenCalledWith(["--version"]);
-    expect(result.baselineVersion).toBe("1.6.1");
+    expect(result.baselineVersion).toBe("1.9.0");
     expect(result.detectedVersion).toBe("1.5.9");
     expect(result.compatibilityStatus).toBe("possibly_incompatible");
   });
@@ -51,7 +51,7 @@ describe("read-only handlers", () => {
 
   it("checkStatusHandler combines version and connectivity checks", async () => {
     const runner = makeRunner(async (args) => {
-      if (args[0] === "--version") return { stdout: "1.6.1 (abc123)", stderr: "" };
+      if (args[0] === "--version") return { stdout: "1.9.0 (abc123)", stderr: "" };
       if (args[0] === "test") return { stdout: "Connection successful", stderr: "" };
       return { stdout: "", stderr: "" };
     });
@@ -78,7 +78,7 @@ describe("read-only handlers", () => {
 
   it("checkStatusHandler enriches structuredContent with auth error fields", async () => {
     const runner = makeRunner(async (args) => {
-      if (args[0] === "--version") return { stdout: "1.6.1 (abc123)", stderr: "" };
+      if (args[0] === "--version") return { stdout: "1.9.0 (abc123)", stderr: "" };
       throw new PassCliAuthError("AUTH_EXPIRED");
     });
 


### PR DESCRIPTION
- Update PROJECT_PASS_CLI_BASELINE_VERSION from 1.6.1 to 1.9.0
- Add accept_invite and reject_invite to README tool table
- Update upstream metadata latest_known_version to 1.9.0
- Update mock and test fixtures to reflect new baseline version

The invite accept/reject handlers, schemas, command catalog entries, and tool definitions were already implemented in a prior commit. v1.9.0 adds background SSH agent daemon (out of scope) and streamlined invite acceptance workflow (already covered).