### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@4d99459187151e4e55600741e3b4320ab66adfd2
+        with:
+          mode: validate
+          skill-dir: skills/pass-cli-mcp
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This adds a single workflow that validates skill metadata at PR level without touching runtime code or release flow.

The workflow only runs validation , won't publish, won't touch credentials, and can be reverted with one commit.

- Runs validator in validate mode for `skills/pass-cli-mcp`
- Checks schema and trust signals only
- Leaves existing code and release pipelines untouched

Happy to point this at a different path or fold it into an existing workflow if you prefer.