### PR TITLE
chore(security): scope workflow token permissions to jobs that need w…

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -6,8 +6,7 @@ on:
       - published
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   publish-npm:
@@ -16,6 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: npm-publish
+    # Job-level write grants only where actually needed:
+    #   contents: write  -> `gh release upload` (steps[9])
+    #   id-token: write  -> npm trusted publishing OIDC (steps[10])
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v5

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,13 +7,18 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    # Job-level write grants only where actually needed:
+    #   contents: write       -> release-please creates release commits and tags
+    #   pull-requests: write  -> release-please opens and updates the release PR
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Run Release Please
         uses: googleapis/release-please-action@v4

--- a/.github/workflows/upstream-pass-cli-watch.yml
+++ b/.github/workflows/upstream-pass-cli-watch.yml
@@ -6,13 +6,18 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   watch-upstream:
     name: Watch upstream latest version tag
     runs-on: ubuntu-latest
+    # Job-level write grants only where actually needed:
+    #   contents: write       -> peter-evans/create-pull-request pushes a chore branch
+    #   pull-requests: write  -> peter-evans/create-pull-request opens the PR
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Addresses OSSF Scorecard's Token-Permissions check (currently 0/10). Three workflows granted write scopes at the top level, which leaks permission scope to any future job added to the workflow. Moving the writes to the single job in each file that actually needs them and leaving the top level at contents: read, which is Scorecard's preferred restrictive default.

publish-npm.yml:
  top level: contents: read (was: contents: write, id-token: write)
  publish-npm job: contents: write (gh release upload),
                   id-token: write (npm trusted publishing OIDC)

release-please.yml:
  top level: contents: read (was: contents: write, pull-requests: write)
  release-please job: contents: write (release commits and tags),
                      pull-requests: write (release PR updates)

upstream-pass-cli-watch.yml:
  top level: contents: read (was: contents: write, pull-requests: write)
  watch-upstream job: contents: write (peter-evans/create-pull-request
                                       pushes the chore branch),
                      pull-requests: write (open the PR)

No functional change - the actions that need the writes still have them via job-level grants. Verified with the ossf-scorecard plugin's workflow-audit skill: token-permissions domain now reports 0 findings.

🤖 Generated with Claude Code