### PR TITLE
chore(security): pin github actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/conventional-pr-title.yml
+++ b/.github/workflows/conventional-pr-title.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce Conventional Commits PR title
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/production-hygiene.yml
+++ b/.github/workflows/production-hygiene.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,12 +18,12 @@ jobs:
       name: npm-publish
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Setup Node.js 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Please
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           release-type: node

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/upstream-pass-cli-watch.yml
+++ b/.github/workflows/upstream-pass-cli-watch.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js 24
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: Open PR for metadata update
         if: steps.watch.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: "chore: track pass-cli v${{ steps.watch.outputs.version }}"
           title: "chore: track pass-cli v${{ steps.watch.outputs.version }}"


### PR DESCRIPTION
Addresses OSSF Scorecard's Pinned-Dependencies check (currently 5/10). All third-party actions were pinned to floating major-version tags (actions/checkout@v5, googleapis/release-please-action@v4, etc), which means a compromised tag upstream would silently run in CI. Scorecard wants every `uses:` ref to pin to a 40-character commit SHA; the `# v<major>` comment preserves the intent and lets Dependabot propose updates.

No major version upgrades performed - each SHA is whatever the existing major-tag currently points to on its upstream repo. The new references are:

  actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
  actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
  amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
  googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
  github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
  peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7

Touches seven workflows: ci.yml, conventional-pr-title.yml, production-hygiene.yml, publish-npm.yml, release-please.yml, scorecard.yml, upstream-pass-cli-watch.yml. scorecard.yml already had the first-party actions pinned; this completes it with the codeql upload-sarif step.

Verified with the ossf-scorecard plugin's workflow-audit skill: pinned-dependencies domain now reports 0 findings.

🤖 Generated with Claude Code