### PR TITLE
docs(security): add reporting links to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,8 @@ Please do not open public issues for suspected security vulnerabilities.
 
 Instead:
 
-- Open a private GitHub security advisory for this repository.
+- [Open a private GitHub security advisory for this repository](https://github.com/hesreallyhim/proton-pass-community-mcp/security/advisories/new).
+- See GitHub's [private vulnerability reporting guide](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) if you are unfamiliar with the flow.
 
 Security concerns will be treated with urgency due to the sensitive nature of the library.
 


### PR DESCRIPTION
Addresses OSSF Scorecard's Security-Policy check (currently 4/10). The file already had disclosure language and free-form text but Scorecard's `securityPolicyContainsLinks` probe failed because no http(s):// URL or email address was present:

  Warn: no linked content found

Adding two links:

1. A direct deeplink to this repo's private advisory creation form https://github.com/hesreallyhim/proton-pass-community-mcp/security/advisories/new so reporters can land on the form in one click.

2. A reference link to GitHub's general docs on private vulnerability reporting, for reporters who are not familiar with the flow.

No change to the policy text or scope. Pure URL addition; the disclosure expectations and scope notes are unchanged.

Expected score impact: 4/10 -> 10/10 on next Scorecard run (satisfies all four securityPolicy* probes).

🤖 Generated with Claude Code