### PR TITLE
chore(security): drop trailing slash from npm registry URL for scorec…

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          registry-url: https://registry.npmjs.org/
+          registry-url: https://registry.npmjs.org
 
       - name: Verify trusted publishing runtime minimums
         shell: bash


### PR DESCRIPTION
Addresses OSSF Scorecard's Packaging check (currently -1/10 "packaging workflow not detected"). Scorecard's IsPackagingWorkflow matcher in checks/fileparser/github_workflow.go does a strict string equality on with.registry-url:

  Uses: "actions/setup-node",
  With: map[string]string{"registry-url": "https://registry.npmjs.org"},

The matcher then enforces input.Value.Value != valToMatch which fails on our existing line because it was

  registry-url: https://registry.npmjs.org/

with a trailing slash. The two URLs are functionally identical to npm itself - the registry accepts both - but Scorecard only sees the exact string and skips the workflow as "not a packaging workflow", meaning the entire check returns -1 (no detection).

Removing the trailing slash so Scorecard's matcher recognises this as a node packaging workflow on its next run. No functional change to npm publishing.

Expected score impact: -1 -> 10 on next Scorecard run.

🤖 Generated with Claude Code