### PR TITLE
docs: clarify response time for security reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,8 @@ Instead:
 
 Security concerns will be treated with urgency due to the sensitive nature of the library.
 
+An initial response may be expected within 7 days. 
+
 ## Report Expectations
 
 Include:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ Instead:
 
 Security concerns will be treated with urgency due to the sensitive nature of the library.
 
-An initial response may be expected within 7 days. 
+An initial response may be expected within 7 days.
 
 ## Report Expectations
 


### PR DESCRIPTION
Added a note about expected response time for security concerns.