### PR TITLE
fix(pkg): ship item-create-templates snapshot in published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "provenance": true
   },
   "files": [
-    "dist"
+    "dist",
+    "docs/testing/item-create-templates.snapshot.json"
   ],
   "scripts": {
     "dev": "tsx src/index.ts",


### PR DESCRIPTION
## What & why

The published npm package crashes on startup for every released version (`1.0.2`, `1.1.0`, `1.1.2`) with:

```
Error: ENOENT: no such file or directory, open '.../proton-pass-community-mcp/docs/testing/item-create-templates.snapshot.json'
    at loadSnapshot (.../dist/resources/item-create-templates.js:11:17)
    at registerResources (.../dist/server/register-resources.js:19:22)
```

`registerResources()` eagerly calls `getItemCreateTemplateSnapshot()`, which reads `docs/testing/item-create-templates.snapshot.json` (resolved relative to the package root). The file exists in the repo, but `package.json`'s `"files": ["dist"]` whitelist excluded it from the published tarball, so the server never starts via `npx`.

See #130 for full root-cause analysis.

## The fix

Add the runtime asset to the `files` whitelist so it ships in the tarball:

```diff
 "files": [
-  "dist"
+  "dist",
+  "docs/testing/item-create-templates.snapshot.json"
 ]
```

Minimal, no code or path changes.

## Verification

- `npm pack` before: tarball has 54 files, snapshot absent.
- `npm pack` after: tarball has 55 files, includes `docs/testing/item-create-templates.snapshot.json` (2.3 kB).
- Clean install from the packed tarball into a fresh dir, then `node node_modules/proton-pass-community-mcp/dist/index.js` → server logs `started` and returns a valid `initialize` result instead of crashing.

Fixes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
