### PR TITLE
fix(deps): resolve qs security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4645,9 +4645,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
     "typescript-eslint": "^8.68.0",
     "vitest": "^4.1.11"
   },
+  "overrides": {
+    "qs": "6.16.0"
+  },
   "allowScripts": {
     "esbuild@0.28.2": true,
     "fsevents@2.3.3": true


### PR DESCRIPTION
## Summary
- add an npm override for transitive `qs@6.16.0`
- update the lockfile from `qs@6.15.3` to the patched release
- resolve Dependabot alert #54 and the related `qs` denial-of-service advisory

## Major-risk notes
- No major version updates. The override is a patch/minor transitive update; no code or configuration changes were required.

## Verification
- `npm audit --omit=dev --json` — 0 vulnerabilities
- `npm run lint`
- `npm run typecheck`
- `npm test` — 247 passed
- `npm run build`

## Follow-up
- None.